### PR TITLE
Wrap the tokio runtime in a Mutex.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ tokio = { version = "0.2", optional = true, features = ["rt-core", "blocking", "
 # core = { package = "core-futures-tls", version = "0.1.0", optional = true }
 lightproc = { version = "0.3.4", optional = true }
 atomic_refcell = { version = "0.1.6", optional = true }
+
+[dev-dependencies.tokio]
+features = ["rt-core", "blocking", "time" ]

--- a/tests/tokio.rs
+++ b/tests/tokio.rs
@@ -1,17 +1,41 @@
 pub use agnostik::prelude::*;
 
 #[cfg(feature = "runtime_tokio")]
-#[test]
-fn test_tokio() {
-    let agnostik = Agnostik::tokio();
+mod tokio_tests {
+    use super::*;
+    #[test]
+    fn test_tokio() {
+        let agnostik = Agnostik::tokio();
 
-    let handle = agnostik.spawn(async {
-        let mut i = 0;
-        while i < 5 {
-            println!("Counting from Tokio: {}", i);
-            i+=1;
+        let handle = agnostik.spawn(async {
+            let mut i = 0;
+            while i < 5 {
+                println!("Counting from Tokio: {}", i);
+                i += 1;
+            }
+        });
+
+        agnostik.block_on(handle);
+    }
+
+    #[test]
+    fn test_basic_scheduler() {
+        let rt = tokio::runtime::Builder::new()
+            .basic_scheduler()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let rt = agnostik::Agnostik::tokio_with_runtime(rt);
+        let rt = std::sync::Arc::new(rt);
+
+        for _ in 0..100 {
+            let rt = rt.clone();
+            std::thread::spawn(move || {
+                rt.block_on(async move {
+                    tokio::time::delay_for(std::time::Duration::from_secs(1)).await
+                });
+            });
         }
-    });
-
-    agnostik.block_on(handle);
+    }
 }


### PR DESCRIPTION
After quite a bit of debate before, we decided to wrap the tokio executor in an AtomicRefCell.
Thanks to help from the tokio team, we've been able to figure out why tokios spawn, spawn_blocking and block_on take a mutable reference to the runtime, trigger a panic using AtomicRefCell, and make sure it doesn't happen again thanks to a mutex.
We also added a test to make sure it won't ever happen anymore.
Thanks again to some tokio contributors who helped us figure out what is going on and how to trigger the error.