### PR TITLE
pass --all-targets --all-features to cargo check and cargo test

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --examples --tests
+          args: --all-targets --all-features --examples --tests
 
       - name: tests (nightly)
         if: matrix.version == 'nightly'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --examples --tests
+          args: --all-targets --all-features --examples --tests
 
       - name: tests (nightly)
         if: matrix.version == 'nightly'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --examples --tests
+          args: --all-targets --all-features --examples --tests
 
       - name: tests (nightly)
         if: matrix.version == 'nightly'


### PR DESCRIPTION
As explained in the cargo check documentation:
> --all: Deprecated alias for --workspace.

This patch adds full checks to our ci builds.