### PR TITLE
Tokio fix

### DIFF
--- a/src/executor/tokio.rs
+++ b/src/executor/tokio.rs
@@ -31,7 +31,7 @@ impl AgnostikExecutor for TokioExecutor {
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        let handle = self.0.lock().unwrap().spawn(future);
+        let handle = tokio::task::spawn(future);
         JoinHandle(InnerJoinHandle::Tokio(handle))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,11 @@
 //! ```ignore
 //! fn main() {
 //!     let result = agnostik::block_on(async {
-//!         agnostik::spawn(async { println!("Hello from bastion executor!"); 1 }).await
+//!         agnostik::spawn(async {
+//!             println!("Hello from bastion executor!");
+//!             1
+//!          })
+//!          .await
 //!     });
 //!     assert_eq!(result, 1);
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,8 +77,9 @@
 //!
 //! ```ignore
 //! fn main() {
-//!     let future = agnostik::spawn(async { println!("Hello from bastion executor!"); 1 });
-//!     let result = agnostik::block_on(future);
+//!     let result = agnostik::block_on(async {
+//!         agnostik::spawn(async { println!("Hello from bastion executor!"); 1 }).await
+//!     });
 //!     assert_eq!(result, 1);
 //! }
 //! ```

--- a/tests/asyncstd.rs
+++ b/tests/asyncstd.rs
@@ -9,7 +9,7 @@ fn test_async_std() {
         let mut i = 0;
         while i < 5 {
             println!("Counting from Asyncstd: {}", i);
-            i+=1;
+            i += 1;
         }
     });
 
@@ -19,6 +19,12 @@ fn test_async_std() {
 #[cfg(feature = "runtime_asyncstd")]
 #[test]
 fn test_async_std_implicit() {
-    let res = agnostik::block_on(async { agnostik::spawn(async { println!("hello world"); 1 }).await });
+    let res = agnostik::block_on(async {
+        agnostik::spawn(async {
+            println!("hello world");
+            1
+        })
+        .await
+    });
     assert_eq!(res, 1);
 }

--- a/tests/asyncstd.rs
+++ b/tests/asyncstd.rs
@@ -15,3 +15,10 @@ fn test_async_std() {
 
     agnostik.block_on(handle);
 }
+
+#[cfg(feature = "runtime_asyncstd")]
+#[test]
+fn test_async_std_implicit() {
+    let res = agnostik::block_on(async { agnostik::spawn(async { println!("hello world"); 1 }).await });
+    assert_eq!(res, 1);
+}

--- a/tests/bastion.rs
+++ b/tests/bastion.rs
@@ -9,7 +9,7 @@ fn test_bastion() {
         let mut i = 0;
         while i < 5 {
             println!("Counting from Bastion: {}", i);
-            i+=1;
+            i += 1;
         }
     });
 

--- a/tests/tokio.rs
+++ b/tests/tokio.rs
@@ -6,13 +6,15 @@ mod tokio_tests {
     use super::*;
     #[test]
     fn test_tokio() {
-        agnostik::block_on(async { agnostik::spawn(async {
-            let mut i = 0;
-            while i < 5 {
-                println!("Counting from Tokio: {}", i);
-                i += 1;
-            }
-        })});
+        agnostik::block_on(async {
+            agnostik::spawn(async {
+                let mut i = 0;
+                while i < 5 {
+                    println!("Counting from Tokio: {}", i);
+                    i += 1;
+                }
+            })
+        });
     }
 
     #[test]
@@ -34,6 +36,12 @@ mod tokio_tests {
 #[cfg(feature = "runtime_tokio")]
 #[test]
 fn test_tokio_implicit() {
-    let res = agnostik::block_on(async { agnostik::spawn(async { println!("hello world"); 1 }).await });
+    let res = agnostik::block_on(async {
+        agnostik::spawn(async {
+            println!("hello world");
+            1
+        })
+        .await
+    });
     assert_eq!(res, 1);
 }

--- a/tests/tokio.rs
+++ b/tests/tokio.rs
@@ -6,17 +6,13 @@ mod tokio_tests {
     use super::*;
     #[test]
     fn test_tokio() {
-        let agnostik = Agnostik::tokio();
-
-        let handle = agnostik.spawn(async {
+        agnostik::block_on(async { agnostik::spawn(async {
             let mut i = 0;
             while i < 5 {
                 println!("Counting from Tokio: {}", i);
                 i += 1;
             }
-        });
-
-        agnostik.block_on(handle);
+        })});
     }
 
     #[test]
@@ -33,4 +29,11 @@ mod tokio_tests {
             });
         }
     }
+}
+
+#[cfg(feature = "runtime_tokio")]
+#[test]
+fn test_tokio_implicit() {
+    let res = agnostik::block_on(async { agnostik::spawn(async { println!("hello world"); 1 }).await });
+    assert_eq!(res, 1);
 }


### PR DESCRIPTION
Hi there,

As you can see from the added tests this works now in both async-std and tokio.

```rust
let res = agnostik::block_on(async {
    agnostik::spawn(async {
        println!("hello world");
        1
    })
    .await
});
assert_eq!(res, 1);
```