### PR TITLE
Remove default.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ homepage    = "https://github.com/bastion-rs/agnostik"
 edition     = "2018"
 
 [features]
-default = ["runtime_bastion"]
 runtime_bastion = ["bastion-executor", "lightproc"]
 runtime_asyncstd = ["async_std_crate"]
 runtime_tokio = ["tokio_crate"]


### PR DESCRIPTION
To really be executor agnostic, I think there shouldn't be a default executor enabled. The other issue is that if you enable an executor, you also need to set `no-default-features` and in the library case you don't want any executor so you also need to disable the default. Considering this, it's likely a good idea to not enable an executor by default.