### PR TITLE
Add attributes.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,9 +10,6 @@ jobs:
         version:
           - stable
           - nightly
-    defaults:
-      run:
-        shell: sh
 
     name: ${{ matrix.version }} - x86_64-unknown-linux-gnu
     runs-on: ubuntu-latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,6 +10,9 @@ jobs:
         version:
           - stable
           - nightly
+    defaults:
+      run:
+        shell: sh
 
     name: ${{ matrix.version }} - x86_64-unknown-linux-gnu
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ once_cell = "1.5.2"
 pin-project = "1.0.2"
 
 [dev-dependencies]
-agnostik = { path = ".", features = ["attributes", "runtime_bastion"] }
+agnostik = { path = ".", features = ["attributes"] }
 tokio_crate = { version = "0.3.4", features = ["time"], package = "tokio" }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = [".", "attributes"]
+
 [package]
 name        = "agnostik"
 version     = "0.2.1-alpha.0"
@@ -15,7 +18,7 @@ runtime_tokio = ["tokio_crate"]
 runtime_smol = ["smol_crate"]
 
 [dependencies]
-agnostik-attributes = { version = "1.1.1", optional = true }
+agnostik-attributes = { path = "attributes", optional = true }
 bastion-executor = { version = "0.4.0", optional = true }
 async_std_crate = { version = "1.7.0", optional = true, features = ["unstable"], package = "async-std" }
 tokio_crate = { version = "0.3.4", optional = true, features = ["rt", "rt-multi-thread"], package = "tokio" }
@@ -25,7 +28,7 @@ once_cell = "1.5.2"
 pin-project = "1.0.2"
 
 [dev-dependencies]
-agnostik = { path = ".", features = ["attributes"] }
+agnostik = { path = ".", features = ["attributes", "runtime_bastion"] }
 tokio_crate = { version = "0.3.4", features = ["time"], package = "tokio" }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,14 @@ homepage    = "https://github.com/bastion-rs/agnostik"
 edition     = "2018"
 
 [features]
+attributes = ["agnostik-attributes"]
 runtime_bastion = ["bastion-executor", "lightproc"]
 runtime_asyncstd = ["async_std_crate"]
 runtime_tokio = ["tokio_crate"]
 runtime_smol = ["smol_crate"]
 
 [dependencies]
+agnostik-attributes = { version = "1.1.1", optional = true }
 bastion-executor = { version = "0.4.0", optional = true }
 async_std_crate = { version = "1.7.0", optional = true, features = ["unstable"], package = "async-std" }
 tokio_crate = { version = "0.3.4", optional = true, features = ["rt", "rt-multi-thread"], package = "tokio" }
@@ -23,6 +25,7 @@ once_cell = "1.5.2"
 pin-project = "1.0.2"
 
 [dev-dependencies]
+agnostik = { path = ".", features = ["attributes"] }
 tokio_crate = { version = "0.3.4", features = ["time"], package = "tokio" }
 
 [build-dependencies]

--- a/attributes/Cargo.toml
+++ b/attributes/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "agnostik-attributes"
+description = "Experimental language-level polyfills for Async Rust."
+version = "1.1.1"
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/bastion-rs/agnostik"
+homepage = "https://github.com/bastion-rs/agnostik"
+documentation = "https://docs.rs/agnostik-attributes"
+authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
+keywords = ["async", "await", "macro", "futures"]
+categories = ["asynchronous", "network-programming", "filesystem", "concurrency", "api-bindings"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1.0.48", features = ["full"] }
+quote = "1.0.7"
+
+[dev-dependencies]
+agnostik = { path = "..", features = ["attributes", "runtime_bastion"] }

--- a/attributes/Cargo.toml
+++ b/attributes/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "agnostik-attributes"
-description = "Experimental language-level polyfills for Async Rust."
+description = "Executor agnostik attributes."
 version = "1.1.1"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/bastion-rs/agnostik"
 homepage = "https://github.com/bastion-rs/agnostik"
 documentation = "https://docs.rs/agnostik-attributes"
-authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
+authors = ["Agnostik Developers"]
 keywords = ["async", "await", "macro", "futures"]
 categories = ["asynchronous", "network-programming", "filesystem", "concurrency", "api-bindings"]
 edition = "2018"

--- a/attributes/Cargo.toml
+++ b/attributes/Cargo.toml
@@ -20,4 +20,4 @@ syn = { version = "1.0.48", features = ["full"] }
 quote = "1.0.7"
 
 [dev-dependencies]
-agnostik = { path = "..", features = ["attributes", "runtime_bastion"] }
+agnostik = { path = "..", features = ["attributes"] }

--- a/attributes/src/lib.rs
+++ b/attributes/src/lib.rs
@@ -1,0 +1,172 @@
+//! Experimental language-level polyfills for Async Rust.
+//!
+//! # Examples
+//!
+//! ```
+//! #[agnostik::main]
+//! async fn main() {
+//!     println!("Hello, world!");
+//! }
+//! ```
+//!
+//! # About
+//!
+//! Async Rust is a work in progress. The language has enabled us to do some
+//! fantastic things, but not everything is figured out yet. This crate exists
+//! to polyfill language-level support for async idioms before they can be part
+//! of the language.
+//!
+//! A great example of this is `async fn main`, which we first introduced as
+//! part of the [`runtime`](https://docs.rs/runtime/0.3.0-alpha.7/runtime/) crate.
+//! Its premise is that if `async fn` is required for every `await` call, it
+//! makes sense to apply that even to `fn main`. Unfortunately this would
+//! require compiler support to enable, so we've provided an experimental
+//! polyfill for it in the mean time.
+
+#![forbid(unsafe_code, future_incompatible, rust_2018_idioms)]
+#![deny(missing_debug_implementations, nonstandard_style)]
+#![recursion_limit = "512"]
+
+use proc_macro::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::spanned::Spanned;
+
+/// Enables an async main function.
+///
+/// # Examples
+///
+/// ```ignore
+/// #[agnostik::main]
+/// async fn main() -> std::io::Result<()> {
+///     Ok(())
+/// }
+/// ```
+#[cfg(not(test))] // NOTE: exporting main breaks tests, we should file an issue.
+#[proc_macro_attribute]
+pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as syn::ItemFn);
+
+    let ret = &input.sig.output;
+    let inputs = &input.sig.inputs;
+    let name = &input.sig.ident;
+    let body = &input.block;
+    let attrs = &input.attrs;
+    let vis = &input.vis;
+
+    if name != "main" {
+        return TokenStream::from(quote_spanned! { name.span() =>
+            compile_error!("only the main function can be tagged with #[agnostik::main]"),
+        });
+    }
+
+    if input.sig.asyncness.is_none() {
+        return TokenStream::from(quote_spanned! { input.span() =>
+            compile_error!("the async keyword is missing from the function declaration"),
+        });
+    }
+
+    let result = quote! {
+        #vis fn main() #ret {
+            #(#attrs)*
+            async fn main(#inputs) #ret {
+                #body
+            }
+
+            agnostik::block_on(async {
+                main().await
+            })
+        }
+
+    };
+
+    result.into()
+}
+
+/// Enables an async test function.
+///
+/// # Examples
+///
+/// ```ignore
+/// #[agnostik::test]
+/// async fn my_test() -> std::io::Result<()> {
+///     assert_eq!(2 * 2, 4);
+///     Ok(())
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn test(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as syn::ItemFn);
+
+    let ret = &input.sig.output;
+    let name = &input.sig.ident;
+    let body = &input.block;
+    let attrs = &input.attrs;
+    let vis = &input.vis;
+
+    if input.sig.asyncness.is_none() {
+        return TokenStream::from(quote_spanned! { input.span() =>
+            compile_error!("the async keyword is missing from the function declaration"),
+        });
+    }
+
+    let result = quote! {
+        #[test]
+        #(#attrs)*
+        #vis fn #name() #ret {
+            agnostik::block_on(async { #body })
+        }
+    };
+
+    result.into()
+}
+
+/// Enables an async benchmark function.
+///
+/// # Examples
+///
+/// ```ignore
+/// #![feature(test)]
+/// extern crate test;
+///
+/// #[agnostik::bench]
+/// async fn bench_1(b: &mut test::Bencher) {
+///     b.iter(|| {
+///         println!("hello world");
+///     })
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn bench(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as syn::ItemFn);
+
+    let ret = &input.sig.output;
+    let args = &input.sig.inputs;
+    let name = &input.sig.ident;
+    let body = &input.block;
+    let attrs = &input.attrs;
+    let vis = &input.vis;
+
+    if input.sig.asyncness.is_none() {
+        return TokenStream::from(quote_spanned! { input.span() =>
+            compile_error!("the async keyword is missing from the function declaration"),
+        });
+    }
+
+    if !args.is_empty() {
+        return TokenStream::from(quote_spanned! { args.span() =>
+            compile_error!("async benchmarks don't take any arguments"),
+        });
+    }
+
+    let result = quote! {
+        #[bench]
+        #(#attrs)*
+        #vis fn #name(b: &mut test::Bencher) #ret {
+            task::block_on(task::spawn(async {
+                #body
+            }))
+        }
+    };
+
+    result.into()
+}

--- a/attributes/src/lib.rs
+++ b/attributes/src/lib.rs
@@ -1,4 +1,4 @@
-//! Experimental language-level polyfills for Async Rust.
+//! Executor agnostik attributes.
 //!
 //! # Examples
 //!
@@ -8,20 +8,6 @@
 //!     println!("Hello, world!");
 //! }
 //! ```
-//!
-//! # About
-//!
-//! Async Rust is a work in progress. The language has enabled us to do some
-//! fantastic things, but not everything is figured out yet. This crate exists
-//! to polyfill language-level support for async idioms before they can be part
-//! of the language.
-//!
-//! A great example of this is `async fn main`, which we first introduced as
-//! part of the [`runtime`](https://docs.rs/runtime/0.3.0-alpha.7/runtime/) crate.
-//! Its premise is that if `async fn` is required for every `await` call, it
-//! makes sense to apply that even to `fn main`. Unfortunately this would
-//! require compiler support to enable, so we've provided an experimental
-//! polyfill for it in the mean time.
 
 #![forbid(unsafe_code, future_incompatible, rust_2018_idioms)]
 #![deny(missing_debug_implementations, nonstandard_style)]

--- a/ci.sh
+++ b/ci.sh
@@ -9,7 +9,6 @@ if [ "$1" = "check" ]; then
     cargo check --features=runtime_tokio
     cargo check --features=runtime_smol
 elif [ "$1" = "test" ]; then
-    cargo test
     cargo test --features=runtime_bastion
     cargo test --features=runtime_asyncstd
     cargo test --features=runtime_tokio

--- a/ci.sh
+++ b/ci.sh
@@ -2,13 +2,13 @@
 
 set -em
 
-if [ "$1" == "check" ]; then
+if [ "$1" = "check" ]; then
     cargo check
     cargo check --features=runtime_bastion
     cargo check --features=runtime_asyncstd
     cargo check --features=runtime_tokio
     cargo check --features=runtime_smol
-elif [ "$1" == "test" ]; then
+elif [ "$1" = "test" ]; then
     cargo test
     cargo test --features=runtime_bastion
     cargo test --features=runtime_asyncstd

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,15 @@
 //! }
 //! ```
 //!
+//! or use the attribute macros.
+//!
+//! ```
+//! #[agnostik::main]
+//! async fn main() {
+//!     println!("hello world");
+//! }
+//! ```
+//!
 //! If you want to use another exceutor, you just have to replace the `Agnostik::bastion()`
 //! method call, with the method that corresponds to your executor.
 //!
@@ -145,6 +154,8 @@
 
 pub mod executor;
 pub mod join_handle;
+#[cfg(feature = "attributes")]
+pub use agnostik_attributes::{bench, main, test};
 
 use join_handle::JoinHandle;
 #[allow(unused)]


### PR DESCRIPTION
I'm happy to transfer the `agnostik-attributes` repo. It's essentially the same as `async-attributes` but using agnostik instead of `async-std`.