### PR TITLE
Update tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ attributes = ["agnostik-attributes"]
 runtime_bastion = ["bastion-executor", "lightproc"]
 runtime_asyncstd = ["async_std_crate"]
 runtime_tokio = ["tokio_crate"]
+runtime_tokio1 = ["tokio1_crate"]
 runtime_smol = ["smol_crate"]
 
 [dependencies]
@@ -22,6 +23,7 @@ agnostik-attributes = { version = "1.2.0", optional = true }
 bastion-executor = { version = "0.4", optional = true }
 async_std_crate = { version = "1.7.0", optional = true, features = ["unstable"], package = "async-std" }
 tokio_crate = { version = "0.3.4", optional = true, features = ["rt", "rt-multi-thread"], package = "tokio" }
+tokio1_crate = { version = "1", optional = true, features = ["rt", "rt-multi-thread"], package = "tokio" }
 lightproc = { version = "0.3", optional = true }
 smol_crate = { version = "1.2.4", optional = true, package = "smol" }
 once_cell = "1.5.2"
@@ -30,6 +32,7 @@ pin-project = "1.0.2"
 [dev-dependencies]
 agnostik = { path = ".", features = ["attributes"] }
 tokio_crate = { version = "0.3.4", features = ["time"], package = "tokio" }
+tokio1_crate = { version = "1", features = ["time"], package = "tokio" }
 
 [build-dependencies]
 cfg_aliases = "0.1.1"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ You can choose the executor, by using cargo features.
 There can only be one enabled runtime.
 Valid features are: 
 - `runtime_bastion` to use the [Bastion Executor](https://crates.io/crates/bastion-executor)
-- `runtime_tokio` to use the [Tokio](https://tokio.rs) runtime
+- `runtime_tokio` to use the [Tokio version >0.3.4](https://tokio.rs) runtime
+- `runtime_tokio1` to use the [Tokio version 1.*](https://tokio.rs) runtime
 - `runtime_asyncstd` to use the [AsyncStd](https://async.rs) runtime
 - `runtime_smol` to use the new and awesome [smol](https://docs.rs/smol) runtime
 

--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,7 @@ use std::env;
 const EXECUTOR_FEATURES: &[&str] = &[
     "CARGO_FEATURE_RUNTIME_BASTION",
     "CARGO_FEATURE_RUNTIME_TOKIO",
+    "CARGO_FEATURE_RUNTIME_TOKIO1",
     "CARGO_FEATURE_RUNTIME_ASYNCSTD",
     "CARGO_FEATURE_RUNTIME_SMOL",
 ];
@@ -18,10 +19,11 @@ fn main() {
     cfg_aliases! {
         bastion: { feature = "runtime_bastion" },
         tokio: { feature = "runtime_tokio" },
+        tokio1: { feature = "runtime_tokio1" },
         async_std: { feature = "runtime_asyncstd" },
         smol: { feature = "runtime_smol" },
 
-        local_spawn: { any(tokio, async_std) },
-        enable: { any(smol, tokio, async_std, bastion) },
+        local_spawn: { any(tokio, tokio1, async_std) },
+        enable: { any(smol, tokio, tokio1, async_std, bastion) },
     }
 }

--- a/ci.sh
+++ b/ci.sh
@@ -7,11 +7,13 @@ if [ "$1" = "check" ]; then
     cargo check --features=runtime_bastion
     cargo check --features=runtime_asyncstd
     cargo check --features=runtime_tokio
+    cargo check --features=runtime_tokio1
     cargo check --features=runtime_smol
 elif [ "$1" = "test" ]; then
     cargo test --features=runtime_bastion
     cargo test --features=runtime_asyncstd
     cargo test --features=runtime_tokio
+    cargo test --features=runtime_tokio1
     cargo test --features=runtime_smol
 else
     echo "You have to provide either 'check' or 'test' argument"

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -16,6 +16,11 @@ mod tokio;
 #[cfg(tokio)]
 pub use tokio::*;
 
+#[cfg(tokio1)]
+mod tokio1;
+#[cfg(tokio1)]
+pub use tokio1::*;
+
 #[cfg(smol)]
 mod smol;
 #[cfg(smol)]

--- a/src/executor/tokio1.rs
+++ b/src/executor/tokio1.rs
@@ -1,0 +1,65 @@
+use crate::join_handle::{InnerJoinHandle, JoinHandle};
+use crate::{AgnostikExecutor, LocalAgnostikExecutor};
+use std::future::Future;
+use std::sync::Mutex;
+use tokio1_crate as tokio;
+
+/// A wrapper around the `tokio` (version 1.*) crate which implements `AgnostikExecutor` and
+/// `LocalAgnostikExecutor`.
+pub struct Tokio1Executor(Mutex<tokio::runtime::Runtime>);
+
+impl Tokio1Executor {
+    /// Create a new `Tokio1Executor`.
+    pub fn new() -> Self {
+        Self::with_runtime(tokio::runtime::Runtime::new().expect("failed to create runtime"))
+    }
+
+    /// Create a new `TokioExecutor` with a custom runtime.
+    pub fn with_runtime(runtime: tokio::runtime::Runtime) -> Self {
+        Tokio1Executor(Mutex::new(runtime))
+    }
+
+    pub(crate) fn set_runtime(&self, runtime: tokio::runtime::Runtime) {
+        let mut inner = self.0.lock().unwrap();
+        *inner = runtime;
+    }
+}
+
+impl AgnostikExecutor for Tokio1Executor {
+    fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let handle = tokio::task::spawn(future);
+        JoinHandle(InnerJoinHandle::Tokio1(handle))
+    }
+
+    fn spawn_blocking<F, T>(&self, task: F) -> JoinHandle<T>
+    where
+        F: FnOnce() -> T + Send + 'static,
+        T: Send + 'static,
+    {
+        let handle = tokio::task::spawn_blocking(task);
+        JoinHandle(InnerJoinHandle::Tokio1(handle))
+    }
+
+    fn block_on<F>(&self, future: F) -> F::Output
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        self.0.lock().unwrap().block_on(future)
+    }
+}
+
+impl LocalAgnostikExecutor for Tokio1Executor {
+    fn spawn_local<F>(&self, future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + 'static,
+        F::Output: 'static,
+    {
+        let handle = tokio::task::spawn_local(future);
+        JoinHandle(InnerJoinHandle::Tokio1(handle))
+    }
+}

--- a/tests/tokio1.rs
+++ b/tests/tokio1.rs
@@ -1,0 +1,47 @@
+pub use agnostik::prelude::*;
+pub use tokio1_crate as tokio;
+
+#[cfg(feature = "runtime_tokio1")]
+mod tokio_tests {
+    use super::*;
+    #[test]
+    fn test_tokio() {
+        agnostik::block_on(async {
+            agnostik::spawn(async {
+                let mut i = 0;
+                while i < 5 {
+                    println!("Counting from Tokio: {}", i);
+                    i += 1;
+                }
+            })
+        });
+    }
+
+    #[test]
+    fn test_basic_scheduler() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let rt = std::sync::Arc::new(rt);
+
+        for _ in 0..100 {
+            let rt = rt.clone();
+            std::thread::spawn(move || {
+                rt.block_on(
+                    async move { tokio::time::sleep(std::time::Duration::from_secs(1)).await },
+                );
+            });
+        }
+    }
+}
+
+#[cfg(feature = "runtime_tokio1")]
+#[test]
+fn test_tokio_implicit() {
+    let res = agnostik::block_on(async {
+        agnostik::spawn(async {
+            println!("hello world");
+            1
+        })
+        .await
+    });
+    assert_eq!(res, 1);
+}


### PR DESCRIPTION
I guess this is a breaking change.

Hmm, maybe we should add it as a separate "executor" to also be more "agnostic" over the version? Alternatively could a user [override the agnostik version used by libs](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section)?!

edit: `patch`es are not able to replace one version with another version (they can only change the source to an other source, like a git url). But this works for me: (added to my workspace root Cargo.toml)

```toml
[patch.crates-io]
agnostik = {git = "https://github.com/chpio/agnostik.git", branch = "master"}
```